### PR TITLE
Ignore insecure completion files in zsh compinit

### DIFF
--- a/zshrc
+++ b/zshrc
@@ -18,7 +18,7 @@ fpath=(~/.zsh/completion /usr/local/share/zsh/site-functions $fpath)
 
 # completion
 autoload -U compinit
-compinit
+compinit -u
 
 # load custom executable functions
 for function in ~/.zsh/functions/*; do


### PR DESCRIPTION
#### Context:
- zsh executes "compinit", which initializes the shell completion
- compinit depends on "compaudit" to ensure that the shell completion scripts have secure permissions and ownership (they are _executed_ during tab completion, after all)
- homebrew installs into /usr/local, which is shared by all users on a machine. In order to allow multiple users to use homebrew on one machine, the permissions on /usr/local have to be opened up. Specifically, 
  1. /usr/local and the homebrew cache are owned by a group (e.g. "brew") that multiple users belong to, and
  2. all users in the "brew" group have _write_ permission on /usr/local and the homebrew cache
#### Problem:

Compaudit doesn't approve of the "g+w" permissions on those directories, so it warns interactively at the start of each new shell session
#### Solution

Disabling the strict compaudit compliance allows multiple users to use homebrew on one mac without constant annoying interactive compaudit errrors.
