### PR TITLE
Load rvm last in shell startup sequence

### DIFF
--- a/zshenv
+++ b/zshenv
@@ -5,11 +5,6 @@ export EDITOR=$VISUAL
 # ensure dotfiles bin directory is loaded first
 export PATH="$HOME/.bin:/usr/local/sbin:$PATH"
 
-# load rvm if available
-if which rvm &>/dev/null ; then
-  source ~/.rvm/scripts/rvm
-fi
-
 # mkdir .git/safe in the root of repositories you trust
 export PATH=".git/safe/../../bin:$PATH"
 

--- a/zshrc
+++ b/zshrc
@@ -107,6 +107,11 @@ _load_settings "$HOME/.zsh/configs"
 
 export PATH="$PATH:$HOME/.rvm/bin" # Add RVM to PATH for scripting
 
+# load rvm if available
+if which rvm &>/dev/null ; then
+  source ~/.rvm/scripts/rvm
+fi
+
 hitch() {
   command hitch "$@"
   if [[ -s "$HOME/.hitch_export_authors" ]] ; then


### PR DESCRIPTION
The problem: in tmux, the system ruby was being loaded instead of the rvm ruby.

Fix: move the rvm load script invocation from zshenv to zshrc, because zshrc is sourced AFTER zshenv in the shell load sequence, and the RVM ruby needs to be at the front of $PATH.

See [this blog post](https://shreevatsa.wordpress.com/2008/03/30/zshbash-startup-files-loading-order-bashrc-zshrc-etc/) for the zsh load sequence.

~Chris + Mike
