### PR TITLE
Adding some git aliases

### DIFF
--- a/gitconfig
+++ b/gitconfig
@@ -8,8 +8,11 @@
   aa = add --all
   ap = add --patch
   branches = for-each-ref --sort=-committerdate --format=\"%(color:blue)%(authordate:relative)\t%(color:red)%(authorname)\t%(color:white)%(color:bold)%(refname:short)\" refs/remotes
+  c = commit
   ci = commit -v
   co = checkout
+  difflist = diff --name-only --diff-filter=U
+  poh = push origin head
   st = status
 [core]
   excludesfile = ~/.gitignore


### PR DESCRIPTION
`git poh` is short for `git push origin head`, which pushes any branch to it same-named remote (no need to say `git push origin branch-name`)

`git difflist` helps when rebasing/merging and there are conflicts.  This command will show only a list of files that have conflicts.
