### PR TITLE
Silence `spring stop` errors

### DIFF
--- a/git_template/hooks/post-checkout
+++ b/git_template/hooks/post-checkout
@@ -5,4 +5,4 @@ local_hook="$HOME"/.git_template.local/hooks/post-checkout
 
 .git/hooks/ctags >/dev/null 2>&1 &
 
-spring stop
+spring stop >/dev/null 2>&1 &


### PR DESCRIPTION
This was happening when checking out branches outside of the check-in repo:

<img width="1634" alt="screen shot 2016-01-29 at 1 42 50 pm" src="https://cloud.githubusercontent.com/assets/114617/12684682/3d8b6ebe-c68e-11e5-8112-999d2ac34a6a.png">
