### PR TITLE
Enable tslime.vim when in tmux

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -194,7 +194,7 @@ let g:Tlist_Ctags_Cmd="/usr/local/bin/ctags"
 let g:indentobject_meaningful_indentation = ['haml', 'sass', 'yaml', 'markdown']
 let g:indentLine_fileType = ['yaml']
 
-if system("echo $TMUX | grep tmux &> /dev/null")
+if system("echo $TMUX | grep tmux &> /dev/null && echo 1")
   let g:spec_runner_dispatcher = 'call Send_to_Tmux("clear\n{command}\n")'
   let g:rspec_command = 'call Send_to_Tmux("rspec {spec}\n")'
 endif


### PR DESCRIPTION
- https://trello.com/c/2aISAWxK/1860-re-enable-devs-to-vim-run-their-specs-in-

Lesson learned: vimscript is not POSIX-compliant
