### PR TITLE
Local aliases take precedence

### DIFF
--- a/aliases
+++ b/aliases
@@ -15,9 +15,6 @@ alias s="rspec"
 # Pretty print the path
 alias path='echo $PATH | tr -s ":" "\n"'
 
-# Include custom aliases
-[[ -f ~/.aliases.local ]] && source ~/.aliases.local
-
 # GIT
 alias ga="git add ."
 alias git_tags="git tag -l -n1"
@@ -74,3 +71,6 @@ alias unhitch='hitch -u'
 alias ta="tmux attach-session -t"
 alias tk="tmux kill-session -t"
 alias tl="tmux list-sessions"
+
+# Include custom aliases
+[[ -f ~/.aliases.local ]] && source ~/.aliases.local


### PR DESCRIPTION
Sometimes one wants to use their own version of a shared alias in their `~/.aliases.local`. This makes that possible.

Motivating use case: the `dotfiles` alias is set to `~/dev/epion/dotfiles` in `aliases`. I would like to use the dotfiles repo on my personal laptop, which has its dotfiles in a different spot. Thus, I want to override the team `dotfiles` alias in my `~/.aliases.local` file.
