### PR TITLE
Don't auto-save between tabs

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -12,9 +12,6 @@ set incsearch     " do incremental searching
 set laststatus=2  " Always display the status line
 set autowrite     " Automatically :write before running commands
 
-" Automatically save on focus lost
-autocmd BufLeave,FocusLost * silent! wall
-
 " Switch syntax highlighting on, when the terminal has colors
 " Also switch on highlighting the last used search pattern.
 if (&t_Co > 2 || has("gui_running")) && !exists("syntax_on")


### PR DESCRIPTION
If no one wants this, i'll keep it locally.  It's been annoying with all the alerts in vim when switching tabs after changing branches, etc.  I prefer to save when I expect it to.
